### PR TITLE
Contribution: Performance Data for Worldless

### DIFF
--- a/data/01005B801A82E000.json
+++ b/data/01005B801A82E000.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "1920x1080",
+    "resolutions": [],
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "Runs on the native resolution for this mode",
+    "fps_behavior": "Locked",
+    "target_fps": 60,
+    "fps_notes": ""
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "1280x720",
+    "resolutions": [],
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "Runs on the native resolution for this mode",
+    "fps_behavior": "Locked",
+    "target_fps": 60,
+    "fps_notes": ""
+  }
+}


### PR DESCRIPTION
Submitted by @biase-d via the Titledb Browser.