### PR TITLE
[Contribution] Sumire

### DIFF
--- a/profiles/01003D50126A4000.json
+++ b/profiles/01003D50126A4000.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "1664x936",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": 30,
+    "fps_notes": ""
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "1024x576",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": 30,
+    "fps_notes": ""
+  }
+}


### PR DESCRIPTION
Performance data contribution for **Sumire** (01003D50126A4000) by @ChanseyIsTheBest.