### PR TITLE
[Contribution] OlliOlli World

### DIFF
--- a/profiles/0100C5D01128E000.json
+++ b/profiles/0100C5D01128E000.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Multiple Fixed",
+    "resolution": "",
+    "resolutions": "1920x1080, 1536x864",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "Game drops resolution to 864p during active gameplay in levels",
+    "fps_behavior": "Locked",
+    "target_fps": 60,
+    "fps_notes": ""
+  },
+  "handheld": {
+    "resolution_type": "Multiple Fixed",
+    "resolution": "",
+    "resolutions": "1280x720, 1024x576",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "Game drops resolution to 576p during active gameplay in levels",
+    "fps_behavior": "Locked",
+    "target_fps": 60,
+    "fps_notes": ""
+  }
+}


### PR DESCRIPTION
Performance data contribution for **OlliOlli World** (0100C5D01128E000) by @ChanseyIsTheBest.