### PR TITLE
[Contribution] Pokémon™ Brilliant Diamond

### DIFF
--- a/profiles/0100000011D90000.json
+++ b/profiles/0100000011D90000.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "1280x720",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Stable",
+    "target_fps": 30,
+    "fps_notes": ""
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "1280x720",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Stable",
+    "target_fps": 30,
+    "fps_notes": ""
+  }
+}


### PR DESCRIPTION
Performance data contribution for **Pokémon™ Brilliant Diamond** (0100000011D90000) by @ChanseyIsTheBest.