### PR TITLE
[Contribution] We Love Katamari REROLL+ Royal Reverie

### DIFF
--- a/profiles/0100E71018D1A000.json
+++ b/profiles/0100E71018D1A000.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "1920x1080",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": 30,
+    "fps_notes": "Double buffer V-sync"
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "1280x720",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": 30,
+    "fps_notes": "Double buffer V-sync"
+  }
+}


### PR DESCRIPTION
Performance data contribution for **We Love Katamari REROLL+ Royal Reverie** (0100E71018D1A000) by @ChanseyIsTheBest.