### PR TITLE
[Contribution] Katamari Damacy REROLL

### DIFF
--- a/profiles/0100D7000C2C6000.json
+++ b/profiles/0100D7000C2C6000.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "1920x1080",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": 30,
+    "fps_notes": "Double buffer V-sync"
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "1280x720",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": 30,
+    "fps_notes": "Double buffer V-sync"
+  }
+}


### PR DESCRIPTION
Performance data contribution for **Katamari Damacy REROLL** (0100D7000C2C6000) by @ChanseyIsTheBest.