### PR TITLE
[Contribution] Blasphemous

### DIFF
--- a/graphics/0100698009C6E000.json
+++ b/graphics/0100698009C6E000.json
@@ -1,0 +1,1 @@
+{"docked":{"resolution":{},"framerate":{},"custom":{}},"handheld":{"resolution":{},"framerate":{},"custom":{}},"shared":{}}

--- a/profiles/0100698009C6E000.json
+++ b/profiles/0100698009C6E000.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "1920x1080",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": 60,
+    "fps_notes": ""
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "1280x720",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": 60,
+    "fps_notes": ""
+  }
+}


### PR DESCRIPTION
Performance data contribution for **Blasphemous** (0100698009C6E000) by @biase-d.

This PR also includes graphics settings.