### PR TITLE
[Contribution] Xenoblade Chronicles™ X: Definitive Edition (0100453019AA8000)

### DIFF
--- a/graphics/0100453019AA8000.json
+++ b/graphics/0100453019AA8000.json
@@ -1,0 +1,45 @@
+{
+  "docked": {
+    "resolution": {
+      "resolutionType": "Dynamic",
+      "fixedResolution": "",
+      "minResolution": "1344x760",
+      "maxResolution": "1920x1080",
+      "multipleResolutions": [
+        ""
+      ]
+    },
+    "framerate": {
+      "lockType": "Custom",
+      "targetFps": 30,
+      "apiBuffering": "Double",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "handheld": {
+    "resolution": {
+      "resolutionType": "Dynamic",
+      "fixedResolution": "",
+      "minResolution": "896x504",
+      "maxResolution": "1280x720",
+      "multipleResolutions": [
+        ""
+      ]
+    },
+    "framerate": {
+      "lockType": "Custom",
+      "targetFps": 30,
+      "apiBuffering": "Double",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "shared": {
+    "Antialiasing": {
+      "value": "FXAA",
+      "notes": ""
+    }
+  },
+  "contributor": "masagrator"
+}

--- a/profiles/0100453019AA8000/1.0.2.json
+++ b/profiles/0100453019AA8000/1.0.2.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  }
+}

--- a/videos/0100453019AA8000.json
+++ b/videos/0100453019AA8000.json
@@ -1,0 +1,12 @@
+[
+  {
+    "url": "https://www.youtube.com/watch?v=x6miwExra3o",
+    "notes": "Performance analysis",
+    "submittedBy": "masagrator"
+  },
+  {
+    "url": "https://www.youtube.com/watch?v=AxPbL_X9_i4",
+    "notes": "Docked gameplay with FPS Graph",
+    "submittedBy": "masagrator"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Xenoblade Chronicles™ X: Definitive Edition**.

*   **Title ID:** `0100453019AA8000`
*   **Group ID:** `0100453019AA8000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.2.
*   Added new graphics settings.
*   Added 2 YouTube links.