### PR TITLE
[Contribution] Atelier Escha & Logy: Alchemists of the Dusk Sky DX (0100E5600EE8E000)

### DIFF
--- a/graphics/0100E5600EE8E000.json
+++ b/graphics/0100E5600EE8E000.json
@@ -1,0 +1,42 @@
+{
+  "docked": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "API",
+      "targetFps": 30,
+      "apiBuffering": "Unknown",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "handheld": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "API",
+      "targetFps": 30,
+      "apiBuffering": "Unknown",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "shared": {},
+  "contributor": "masagrator"
+}

--- a/profiles/0100E5600EE8E000/1.0.0.json
+++ b/profiles/0100E5600EE8E000/1.0.0.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  }
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **Atelier Escha & Logy: Alchemists of the Dusk Sky DX**.

*   **Title ID:** `0100E5600EE8E000`
*   **Group ID:** `0100E5600EE8E000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.0.
*   Added new graphics settings.