### PR TITLE
[Contribution] Cel Damage HD (010019B00BE72000)

### DIFF
--- a/graphics/010019B00BE72000.json
+++ b/graphics/010019B00BE72000.json
@@ -1,0 +1,44 @@
+{
+  "docked": {
+    "resolution": {
+      "resolutionType": "Multiple Fixed",
+      "fixedResolution": "",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        "854x480",
+        "1280x720",
+        "1920x1080"
+      ],
+      "notes": "Resolution is adjusted to system setting \"TV Output\""
+    },
+    "framerate": {
+      "lockType": "Custom",
+      "targetFps": 30,
+      "apiBuffering": "Triple",
+      "notes": "Menus are running at 60 FPS"
+    },
+    "custom": {}
+  },
+  "handheld": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "1280x720",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "Custom",
+      "targetFps": 30,
+      "apiBuffering": "Triple",
+      "notes": "Menus are running at 60 FPS"
+    },
+    "custom": {}
+  },
+  "shared": {},
+  "contributor": "masagrator"
+}

--- a/profiles/010019B00BE72000/1.0.0.json
+++ b/profiles/010019B00BE72000/1.0.0.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  }
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **Cel Damage HD**.

*   **Title ID:** `010019B00BE72000`
*   **Group ID:** `010019B00BE72000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.0.
*   Added new graphics settings.