### PR TITLE
[Contribution] OXENFREE (01008B8004E36000)

### DIFF
--- a/graphics/01008B8004E36000.json
+++ b/graphics/01008B8004E36000.json
@@ -1,0 +1,42 @@
+{
+  "docked": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "1920x1080",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "Unlocked",
+      "targetFps": "",
+      "apiBuffering": "Unknown",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "handheld": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "1280x720",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "Unlocked",
+      "targetFps": "",
+      "apiBuffering": "Unknown",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "shared": {},
+  "contributor": "biase-d"
+}


### PR DESCRIPTION
Contribution submitted by @biase-d for **OXENFREE**.

*   **Title ID:** `01008B8004E36000`
*   **Group ID:** `01008B8004E36000`

### Summary of Changes
*   Added empty placeholder for performance v4.1.3.
*   Added new graphics settings.