### PR TITLE
[Contribution] 桃太郎電鐵 ～昭和 平成 令和也是定番！～ Asia Edition (010021801DD26000)

### DIFF
--- a/graphics/010021801DD26000.json
+++ b/graphics/010021801DD26000.json
@@ -1,0 +1,42 @@
+{
+  "docked": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "1920x1080",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "Custom",
+      "targetFps": 30,
+      "apiBuffering": "Triple",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "handheld": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "1280x720",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "Custom",
+      "targetFps": 30,
+      "apiBuffering": "Triple",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "shared": {},
+  "contributor": "masagrator"
+}

--- a/profiles/010021801DD26000/1.0.1.json
+++ b/profiles/010021801DD26000/1.0.1.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  }
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **桃太郎電鐵 ～昭和 平成 令和也是定番！～ Asia Edition**.

*   **Title ID:** `010021801DD26000`
*   **Group ID:** `010021801DD26000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.1.
*   Added new graphics settings.
*   Added 1 YouTube link.