### PR TITLE
[Contribution] OCTOPATH TRAVELER II (0100A3501946E000)

### DIFF
--- a/graphics/0100A3501946E000.json
+++ b/graphics/0100A3501946E000.json
@@ -1,0 +1,42 @@
+{
+  "docked": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "1152x648",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "API",
+      "targetFps": 30,
+      "apiBuffering": "Triple",
+      "notes": "On top of API Lock there is Custom FPS Lock"
+    },
+    "custom": {}
+  },
+  "handheld": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "896x504",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "API",
+      "targetFps": 30,
+      "apiBuffering": "Triple",
+      "notes": "On top of API Lock there is Custom FPS Lock"
+    },
+    "custom": {}
+  },
+  "shared": {},
+  "contributor": "masagrator"
+}

--- a/profiles/0100A3501946E000/1.1.1.json
+++ b/profiles/0100A3501946E000/1.1.1.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  }
+}

--- a/videos/0100A3501946E000.json
+++ b/videos/0100A3501946E000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "url": "https://www.youtube.com/watch?v=XXreGYXAISw",
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **OCTOPATH TRAVELER II**.

*   **Title ID:** `0100A3501946E000`
*   **Group ID:** `0100A3501946E000`

### Summary of Changes
*   Added empty placeholder for performance v1.1.1.
*   Added new graphics settings.
*   Added 1 YouTube link.