### PR TITLE
[Contribution] Pikmin™ 1 (0100AA80194B0000)

### DIFF
--- a/graphics/0100AA80194B0000.json
+++ b/graphics/0100AA80194B0000.json
@@ -1,0 +1,44 @@
+{
+  "docked": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "1920x1080",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "Custom",
+      "targetFps": 30,
+      "apiBuffering": "Double",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "handheld": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "1280x720",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "Custom",
+      "targetFps": 30,
+      "apiBuffering": "Double",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "shared": {},
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/profiles/0100AA80194B0000/1.1.0.json
+++ b/profiles/0100AA80194B0000/1.1.0.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  }
+}

--- a/videos/0100AA80194B0000.json
+++ b/videos/0100AA80194B0000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "url": "https://www.youtube.com/watch?v=Y2V8Sp55GcQ",
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Pikmin™ 1**.

*   **Title ID:** `0100AA80194B0000`
*   **Group ID:** `0100AA80194B0000`

### Summary of Changes
*   Added empty placeholder for performance v1.1.0.
*   Added new graphics settings.
*   Added 1 YouTube link.