### PR TITLE
[Contribution] Pikmin™ 2 (0100D680194B2000)

### DIFF
--- a/graphics/0100D680194B2000.json
+++ b/graphics/0100D680194B2000.json
@@ -1,0 +1,44 @@
+{
+  "docked": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "1920x1080",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "Custom",
+      "targetFps": 30,
+      "apiBuffering": "Double",
+      "notes": "Title Menu is running at 60 FPS"
+    },
+    "custom": {}
+  },
+  "handheld": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "1280x720",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "Custom",
+      "targetFps": 30,
+      "apiBuffering": "Double",
+      "notes": "Title Menu is running at 60 FPS"
+    },
+    "custom": {}
+  },
+  "shared": {},
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/profiles/0100D680194B2000/1.1.0.json
+++ b/profiles/0100D680194B2000/1.1.0.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  }
+}

--- a/videos/0100D680194B2000.json
+++ b/videos/0100D680194B2000.json
@@ -1,0 +1,12 @@
+[
+  {
+    "url": "https://www.youtube.com/watch?v=eJwPqwTyoXA",
+    "notes": "Performance analysis",
+    "submittedBy": "masagrator"
+  },
+  {
+    "url": "https://www.youtube.com/watch?v=dpC14sSnp0c",
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Pikmin™ 2**.

*   **Title ID:** `0100D680194B2000`
*   **Group ID:** `0100D680194B2000`

### Summary of Changes
*   Added empty placeholder for performance v1.1.0.
*   Added new graphics settings.
*   Added 2 YouTube links.