### PR TITLE
[Contribution] Tales of Vesperia™: Definitive Edition (01002C0008E52000)

### DIFF
--- a/graphics/01002C0008E52000.json
+++ b/graphics/01002C0008E52000.json
@@ -1,0 +1,44 @@
+{
+  "docked": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "1920x1080",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "Unlocked",
+      "targetFps": "",
+      "apiBuffering": "Triple",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "handheld": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "1280x720",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "Unlocked",
+      "targetFps": "",
+      "apiBuffering": "Triple",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "shared": {},
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/profiles/01002C0008E52000/1.0.2.json
+++ b/profiles/01002C0008E52000/1.0.2.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  }
+}

--- a/videos/01002C0008E52000.json
+++ b/videos/01002C0008E52000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "url": "https://www.youtube.com/watch?v=nQKDy9hOOOo",
+    "notes": "Docked gameplay with FPS Graph",
+    "submittedBy": "masagrator"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Tales of Vesperia™: Definitive Edition**.

*   **Title ID:** `01002C0008E52000`
*   **Group ID:** `01002C0008E52000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.2.
*   Added new graphics settings.
*   Added 1 YouTube link.