### PR TITLE
[Contribution] Boti: Byteland Overclocked (0100B7C01D480000)

### DIFF
--- a/graphics/0100B7C01D480000.json
+++ b/graphics/0100B7C01D480000.json
@@ -1,0 +1,44 @@
+{
+  "docked": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "API",
+      "targetFps": 30,
+      "apiBuffering": "Double (Reversed)",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "handheld": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "API",
+      "targetFps": 30,
+      "apiBuffering": "Double (Reversed)",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "shared": {},
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/profiles/0100B7C01D480000/1.0.3.json
+++ b/profiles/0100B7C01D480000/1.0.3.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  }
+}

--- a/videos/0100B7C01D480000.json
+++ b/videos/0100B7C01D480000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "url": "https://www.youtube.com/watch?v=GTgPwrFmaiY",
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Boti: Byteland Overclocked**.

*   **Title ID:** `0100B7C01D480000`
*   **Group ID:** `0100B7C01D480000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.3.
*   Added new graphics settings.
*   Added 1 YouTube link.