### PR TITLE
[Contribution] Boti: Byteland Overclocked (0100B7C01D480000)

### DIFF
--- a/graphics/0100B7C01D480000.json
+++ b/graphics/0100B7C01D480000.json
@@ -1,39 +1,39 @@
 {
   "docked": {
     "resolution": {
-      "resolutionType": "Fixed",
-      "fixedResolution": "",
-      "minResolution": "",
+      "notes": "",
       "maxResolution": "",
+      "minResolution": "",
+      "resolutionType": "Dynamic",
+      "fixedResolution": "",
       "multipleResolutions": [
         ""
-      ],
-      "notes": ""
+      ]
     },
     "framerate": {
+      "notes": "",
       "lockType": "API",
       "targetFps": 30,
-      "apiBuffering": "Double (Reversed)",
-      "notes": ""
+      "apiBuffering": "Double (Reversed)"
     },
     "custom": {}
   },
   "handheld": {
     "resolution": {
-      "resolutionType": "Fixed",
-      "fixedResolution": "",
-      "minResolution": "",
+      "notes": "",
       "maxResolution": "",
+      "minResolution": "",
+      "resolutionType": "Dynamic",
+      "fixedResolution": "",
       "multipleResolutions": [
         ""
-      ],
-      "notes": ""
+      ]
     },
     "framerate": {
+      "notes": "",
       "lockType": "API",
       "targetFps": 30,
-      "apiBuffering": "Double (Reversed)",
-      "notes": ""
+      "apiBuffering": "Double (Reversed)"
     },
     "custom": {}
   },

--- a/profiles/0100B7C01D480000/1.0.3.json
+++ b/profiles/0100B7C01D480000/1.0.3.json
@@ -1,24 +1,24 @@
 {
   "docked": {
-    "resolution_type": "Fixed",
-    "resolution": "",
-    "resolutions": "",
-    "min_res": "",
     "max_res": "",
-    "resolution_notes": "",
-    "fps_behavior": "Locked",
+    "min_res": "",
+    "fps_notes": "",
+    "resolution": "",
     "target_fps": "",
-    "fps_notes": ""
+    "resolutions": "",
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed",
+    "resolution_notes": ""
   },
   "handheld": {
-    "resolution_type": "Fixed",
-    "resolution": "",
-    "resolutions": "",
-    "min_res": "",
     "max_res": "",
-    "resolution_notes": "",
-    "fps_behavior": "Locked",
+    "min_res": "",
+    "fps_notes": "",
+    "resolution": "",
     "target_fps": "",
-    "fps_notes": ""
+    "resolutions": "",
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed",
+    "resolution_notes": ""
   }
 }


### PR DESCRIPTION
Contribution submitted by @masagrator for **Boti: Byteland Overclocked**.

*   **Title ID:** `0100B7C01D480000`
*   **Group ID:** `0100B7C01D480000`

### Summary of Changes
*   Updated graphics settings.