### PR TITLE
[Contribution] Circus Electrique (0100ABF015DCE000)

### DIFF
--- a/graphics/0100ABF015DCE000.json
+++ b/graphics/0100ABF015DCE000.json
@@ -1,0 +1,44 @@
+{
+  "docked": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "API",
+      "targetFps": 30,
+      "apiBuffering": "Triple",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "handheld": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "API",
+      "targetFps": 30,
+      "apiBuffering": "Triple",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "shared": {},
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/profiles/0100ABF015DCE000/1.2.0.json
+++ b/profiles/0100ABF015DCE000/1.2.0.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  }
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **Circus Electrique**.

*   **Title ID:** `0100ABF015DCE000`
*   **Group ID:** `0100ABF015DCE000`

### Summary of Changes
*   Added empty placeholder for performance v1.2.0.
*   Added new graphics settings.