### PR TITLE
[Contribution] FINAL FANTASY XII THE ZODIAC AGE (0100EB100AB42000)

### DIFF
--- a/graphics/0100EB100AB42000.json
+++ b/graphics/0100EB100AB42000.json
@@ -1,0 +1,44 @@
+{
+  "docked": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "1536x864",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "API",
+      "targetFps": 30,
+      "apiBuffering": "Triple",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "handheld": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "1024x576",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "API",
+      "targetFps": 30,
+      "apiBuffering": "Triple",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "shared": {},
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/profiles/0100EB100AB42000/1.1.0.json
+++ b/profiles/0100EB100AB42000/1.1.0.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  }
+}

--- a/videos/0100EB100AB42000.json
+++ b/videos/0100EB100AB42000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "url": "https://www.youtube.com/watch?v=r9IGpIehFmQ",
+    "notes": "Platforms compare + Performance analysis",
+    "submittedBy": "masagrator"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **FINAL FANTASY XII THE ZODIAC AGE**.

*   **Title ID:** `0100EB100AB42000`
*   **Group ID:** `0100EB100AB42000`

### Summary of Changes
*   Added empty placeholder for performance v1.1.0.
*   Added new graphics settings.
*   Added 1 YouTube link.