### PR TITLE
[Contribution] GRID™ Autosport (0100DC800A602000)

### DIFF
--- a/graphics/0100DC800A602000.json
+++ b/graphics/0100DC800A602000.json
@@ -1,0 +1,44 @@
+{
+  "docked": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": "In Performance mode resolution is Dynamic"
+    },
+    "framerate": {
+      "lockType": "API",
+      "targetFps": 30,
+      "apiBuffering": "Triple",
+      "notes": "In Performance mode FPS is set to Unlocked"
+    },
+    "custom": {}
+  },
+  "handheld": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": "In Performance mode resolution is Dynamic"
+    },
+    "framerate": {
+      "lockType": "API",
+      "targetFps": 30,
+      "apiBuffering": "Triple",
+      "notes": "In Performance mode FPS is set to Unlocked"
+    },
+    "custom": {}
+  },
+  "shared": {},
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/profiles/0100DC800A602000/1.10.1_70328.json
+++ b/profiles/0100DC800A602000/1.10.1_70328.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  }
+}

--- a/videos/0100DC800A602000.json
+++ b/videos/0100DC800A602000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "url": "https://www.youtube.com/watch?v=mIEdAzlSsWs",
+    "notes": "Performance analysis",
+    "submittedBy": "masagrator"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **GRID™ Autosport**.

*   **Title ID:** `0100DC800A602000`
*   **Group ID:** `0100DC800A602000`

### Summary of Changes
*   Added empty placeholder for performance v1.10.1_70328.
*   Added new graphics settings.
*   Added 1 YouTube link.