### PR TITLE
[Contribution] Katamari Damacy REROLL (0100D7000C2C6000)

### DIFF
--- a/graphics/0100D7000C2C6000.json
+++ b/graphics/0100D7000C2C6000.json
@@ -1,0 +1,44 @@
+{
+  "docked": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "1920x1080",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "API",
+      "targetFps": 30,
+      "apiBuffering": "Double",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "handheld": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "1280x720",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "API",
+      "targetFps": 30,
+      "apiBuffering": "Double",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "shared": {},
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/profiles/0100D7000C2C6000/1.0.0.json
+++ b/profiles/0100D7000C2C6000/1.0.0.json
@@ -1,24 +1,24 @@
 {
   "docked": {
-    "resolution_type": "Fixed",
-    "resolution": "1920x1080",
-    "resolutions": "",
-    "min_res": "",
     "max_res": "",
-    "resolution_notes": "",
-    "fps_behavior": "Locked",
+    "min_res": "",
+    "fps_notes": "",
+    "resolution": "1920x1080",
     "target_fps": 30,
-    "fps_notes": "Double buffer V-sync"
+    "resolutions": "",
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed",
+    "resolution_notes": ""
   },
   "handheld": {
-    "resolution_type": "Fixed",
-    "resolution": "1280x720",
-    "resolutions": "",
-    "min_res": "",
     "max_res": "",
-    "resolution_notes": "",
-    "fps_behavior": "Locked",
+    "min_res": "",
+    "fps_notes": "",
+    "resolution": "1280x720",
     "target_fps": 30,
-    "fps_notes": "Double buffer V-sync"
+    "resolutions": "",
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed",
+    "resolution_notes": ""
   }
 }


### PR DESCRIPTION
Contribution submitted by @masagrator for **Katamari Damacy REROLL**.

*   **Title ID:** `0100D7000C2C6000`
*   **Group ID:** `0100D7000C2C6000`

### Summary of Changes
*   Updated performance data for v1.0.0.
*   Added new graphics settings.