### PR TITLE
[Contribution] LEGO® Jurassic World (01001C100E772000)

### DIFF
--- a/graphics/01001C100E772000.json
+++ b/graphics/01001C100E772000.json
@@ -1,0 +1,44 @@
+{
+  "docked": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "API",
+      "targetFps": 30,
+      "apiBuffering": "Triple",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "handheld": {
+    "resolution": {
+      "resolutionType": "Fixed",
+      "fixedResolution": "",
+      "minResolution": "",
+      "maxResolution": "",
+      "multipleResolutions": [
+        ""
+      ],
+      "notes": ""
+    },
+    "framerate": {
+      "lockType": "API",
+      "targetFps": 30,
+      "apiBuffering": "Triple",
+      "notes": ""
+    },
+    "custom": {}
+  },
+  "shared": {},
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/profiles/01001C100E772000/1.0.1.json
+++ b/profiles/01001C100E772000/1.0.1.json
@@ -1,0 +1,24 @@
+{
+  "docked": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  },
+  "handheld": {
+    "resolution_type": "Fixed",
+    "resolution": "",
+    "resolutions": "",
+    "min_res": "",
+    "max_res": "",
+    "resolution_notes": "",
+    "fps_behavior": "Locked",
+    "target_fps": "",
+    "fps_notes": ""
+  }
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **LEGO® Jurassic World**.

*   **Title ID:** `01001C100E772000`
*   **Group ID:** `01001C100E772000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.1.
*   Added new graphics settings.