### PR TITLE
[Contribution] Oceanhorn 2: Knights of the Lost Realm (01006CB010840000)

### DIFF
--- a/graphics/01006CB010840000.json
+++ b/graphics/01006CB010840000.json
@@ -1,0 +1,25 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "resolutionType": "Dynamic"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "resolutionType": "Dynamic"
+    }
+  }
+}

--- a/profiles/01006CB010840000/1.2.json
+++ b/profiles/01006CB010840000/1.2.json
@@ -1,0 +1,10 @@
+{
+  "docked": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  },
+  "handheld": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  }
+}

--- a/videos/01006CB010840000.json
+++ b/videos/01006CB010840000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=r38QUtoS0Lg"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Oceanhorn 2: Knights of the Lost Realm**.

*   **Title ID:** `01006CB010840000`
*   **Group ID:** `01006CB010840000`

### Summary of Changes
*   Added empty placeholder for performance v1.2.
*   Added new graphics settings.
*   Added 1 YouTube link.