### PR TITLE
[Contribution] Othercide (0100E5900F49A000)

### DIFF
--- a/graphics/0100E5900F49A000.json
+++ b/graphics/0100E5900F49A000.json
@@ -1,0 +1,25 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "resolutionType": "Dynamic"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "resolutionType": "Dynamic"
+    }
+  }
+}

--- a/profiles/0100E5900F49A000/1.3.1.0.json
+++ b/profiles/0100E5900F49A000/1.3.1.0.json
@@ -1,0 +1,10 @@
+{
+  "docked": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  },
+  "handheld": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  }
+}

--- a/videos/0100E5900F49A000.json
+++ b/videos/0100E5900F49A000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=RYN6L5tkxXw"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Othercide**.

*   **Title ID:** `0100E5900F49A000`
*   **Group ID:** `0100E5900F49A000`

### Summary of Changes
*   Added empty placeholder for performance v1.3.1.0.
*   Added new graphics settings.
*   Added 1 YouTube link.