### PR TITLE
[Contribution] OXENFREE II: Lost Signals (010061F0176F6000)

### DIFF
--- a/graphics/010061F0176F6000.json
+++ b/graphics/010061F0176F6000.json
@@ -1,0 +1,25 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/010061F0176F6000/1.4.8.json
+++ b/profiles/010061F0176F6000/1.4.8.json
@@ -1,0 +1,10 @@
+{
+  "docked": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  },
+  "handheld": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  }
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **OXENFREE II: Lost Signals**.

*   **Title ID:** `010061F0176F6000`
*   **Group ID:** `010061F0176F6000`

### Summary of Changes
*   Added empty placeholder for performance v1.4.8.
*   Added new graphics settings.