### PR TITLE
[Contribution] DRAGON QUEST® XI S: Echoes of an Elusive Age – Definitive Edition (01006C300E9F0000)

### DIFF
--- a/graphics/01006C300E9F0000.json
+++ b/graphics/01006C300E9F0000.json
@@ -1,0 +1,29 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "maxResolution": "1600x900",
+      "minResolution": "960x540",
+      "resolutionType": "Dynamic"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "maxResolution": "1088x612",
+      "minResolution": "640x360",
+      "resolutionType": "Dynamic"
+    }
+  }
+}

--- a/profiles/01006C300E9F0000/1.0.4.json
+++ b/profiles/01006C300E9F0000/1.0.4.json
@@ -1,0 +1,10 @@
+{
+  "docked": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  },
+  "handheld": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  }
+}

--- a/videos/01006C300E9F0000.json
+++ b/videos/01006C300E9F0000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Performance analysis",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=Qdm4pB-1Dlc"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **DRAGON QUEST® XI S: Echoes of an Elusive Age – Definitive Edition**.

*   **Title ID:** `01006C300E9F0000`
*   **Group ID:** `01006C300E9F0000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.4.
*   Added new graphics settings.
*   Added 1 YouTube link.