### PR TITLE
[Contribution] FINAL FANTASY VI (0100AA001415E000)

### DIFF
--- a/graphics/0100AA001415E000.json
+++ b/graphics/0100AA001415E000.json
@@ -1,0 +1,25 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "1920x1080",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "1280x720",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/0100AA001415E000/1.2.1.json
+++ b/profiles/0100AA001415E000/1.2.1.json
@@ -1,0 +1,10 @@
+{
+  "docked": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  },
+  "handheld": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  }
+}

--- a/videos/0100AA001415E000.json
+++ b/videos/0100AA001415E000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=1GG6MoE0Oms"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **FINAL FANTASY VI**.

*   **Title ID:** `0100AA001415E000`
*   **Group ID:** `0100AA001415E000`

### Summary of Changes
*   Added empty placeholder for performance v1.2.1.
*   Added new graphics settings.
*   Added 1 YouTube link.