### PR TITLE
[Contribution] SaGa Emerald Beyond (01008BE01E1C2000)

### DIFF
--- a/graphics/01008BE01E1C2000.json
+++ b/graphics/01008BE01E1C2000.json
@@ -1,0 +1,25 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/01008BE01E1C2000/1.04.json
+++ b/profiles/01008BE01E1C2000/1.04.json
@@ -1,0 +1,10 @@
+{
+  "docked": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  },
+  "handheld": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  }
+}

--- a/videos/01008BE01E1C2000.json
+++ b/videos/01008BE01E1C2000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Docked gameplay with FPS Graph",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=Hbw_o76DSAQ"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **SaGa Emerald Beyond**.

*   **Title ID:** `01008BE01E1C2000`
*   **Group ID:** `01008BE01E1C2000`

### Summary of Changes
*   Added empty placeholder for performance v1.04.
*   Added new graphics settings.
*   Added 1 YouTube link.