### PR TITLE
[Contribution] Shin Megami Tensei III Nocturne HD Remaster (01003B0012DC2000)

### DIFF
--- a/graphics/01003B0012DC2000.json
+++ b/graphics/01003B0012DC2000.json
@@ -1,0 +1,25 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/01003B0012DC2000/1.0.3.json
+++ b/profiles/01003B0012DC2000/1.0.3.json
@@ -1,0 +1,10 @@
+{
+  "docked": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  },
+  "handheld": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  }
+}

--- a/videos/01003B0012DC2000.json
+++ b/videos/01003B0012DC2000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=cdfVOla9Jqs"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Shin Megami Tensei III Nocturne HD Remaster**.

*   **Title ID:** `01003B0012DC2000`
*   **Group ID:** `01003B0012DC2000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.3.
*   Added new graphics settings.
*   Added 1 YouTube link.