### PR TITLE
[Contribution] South Park™: The Fractured but Whole™ - Standard Edition (01008F2005154000)

### DIFF
--- a/graphics/01008F2005154000.json
+++ b/graphics/01008F2005154000.json
@@ -1,0 +1,25 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Double",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Double",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/01008F2005154000/1.05.json
+++ b/profiles/01008F2005154000/1.05.json
@@ -1,0 +1,10 @@
+{
+  "docked": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  },
+  "handheld": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  }
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **South Park™: The Fractured but Whole™ - Standard Edition**.

*   **Title ID:** `01008F2005154000`
*   **Group ID:** `01008F2005154000`

### Summary of Changes
*   Added empty placeholder for performance v1.05.
*   Added new graphics settings.