### PR TITLE
[Contribution] Spark the Electric Jester 3 (0100D9901DD98000)

### DIFF
--- a/graphics/0100D9901DD98000.json
+++ b/graphics/0100D9901DD98000.json
@@ -1,0 +1,25 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/0100D9901DD98000/1.1.json
+++ b/profiles/0100D9901DD98000/1.1.json
@@ -1,0 +1,10 @@
+{
+  "docked": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  },
+  "handheld": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  }
+}

--- a/videos/0100D9901DD98000.json
+++ b/videos/0100D9901DD98000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=2fK7z_wckfs"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Spark the Electric Jester 3**.

*   **Title ID:** `0100D9901DD98000`
*   **Group ID:** `0100D9901DD98000`

### Summary of Changes
*   Added empty placeholder for performance v1.1.
*   Added new graphics settings.
*   Added 1 YouTube link.