### PR TITLE
[Contribution] Ys VIII: Lacrimosa of DANA (01007F200B0C0000)

### DIFF
--- a/graphics/01007F200B0C0000.json
+++ b/graphics/01007F200B0C0000.json
@@ -1,0 +1,25 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/01007F200B0C0000/1.05.json
+++ b/profiles/01007F200B0C0000/1.05.json
@@ -1,0 +1,10 @@
+{
+  "docked": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  },
+  "handheld": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  }
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **Ys VIII: Lacrimosa of DANA**.

*   **Title ID:** `01007F200B0C0000`
*   **Group ID:** `01007F200B0C0000`

### Summary of Changes
*   Added empty placeholder for performance v1.05.
*   Added new graphics settings.