### PR TITLE
[Contribution] Ys IX: Monstrum Nox (0100E390124D8000)

### DIFF
--- a/graphics/0100E390124D8000.json
+++ b/graphics/0100E390124D8000.json
@@ -1,0 +1,25 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/0100E390124D8000/1.0.3.json
+++ b/profiles/0100E390124D8000/1.0.3.json
@@ -1,0 +1,10 @@
+{
+  "docked": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  },
+  "handheld": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  }
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **Ys IX: Monstrum Nox**.

*   **Title ID:** `0100E390124D8000`
*   **Group ID:** `0100E390124D8000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.3.
*   Added new graphics settings.