### PR TITLE
[Contribution] Pokkén Tournament™ DX (0100B3F000BE2000)

### DIFF
--- a/graphics/0100B3F000BE2000.json
+++ b/graphics/0100B3F000BE2000.json
@@ -1,0 +1,26 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Double",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "1280x720",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Double",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "maxResolution": "960x720",
+      "minResolution": "480x720",
+      "resolutionType": "Dynamic"
+    }
+  }
+}

--- a/profiles/0100B3F000BE2000/1.3.3.json
+++ b/profiles/0100B3F000BE2000/1.3.3.json
@@ -1,0 +1,10 @@
+{
+  "docked": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  },
+  "handheld": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  }
+}

--- a/videos/0100B3F000BE2000.json
+++ b/videos/0100B3F000BE2000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Platforms comparison + Performance analysis",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=Vc6vshN8K3U"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Pokkén Tournament™ DX**.

*   **Title ID:** `0100B3F000BE2000`
*   **Group ID:** `0100B3F000BE2000`

### Summary of Changes
*   Added empty placeholder for performance v1.3.3.
*   Added new graphics settings.
*   Added 1 YouTube link.