### PR TITLE
[Contribution] Pokémon™: Let’s Go, Pikachu! (010003F003A34000)

### DIFF
--- a/graphics/010003F003A34000.json
+++ b/graphics/010003F003A34000.json
@@ -1,0 +1,27 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Double",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "1920x1080",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Double",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "1280x720",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/010003F003A34000/1.0.2.json
+++ b/profiles/010003F003A34000/1.0.2.json
@@ -1,0 +1,10 @@
+{
+  "docked": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  },
+  "handheld": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  }
+}

--- a/videos/010003F003A34000.json
+++ b/videos/010003F003A34000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Performance analysis",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=_ahNhq2Pj48"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Pokémon™: Let’s Go, Pikachu!**.

*   **Title ID:** `010003F003A34000`
*   **Group ID:** `010003F003A34000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.2.
*   Added new graphics settings.
*   Added 1 YouTube link.