### PR TITLE
[Contribution] Pokémon™: Let’s Go, Eevee! (0100187003A36000)

### DIFF
--- a/graphics/0100187003A36000.json
+++ b/graphics/0100187003A36000.json
@@ -1,0 +1,27 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Double",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "1920x1080",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Double",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "1280x720",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/0100187003A36000/1.0.2.json
+++ b/profiles/0100187003A36000/1.0.2.json
@@ -1,0 +1,10 @@
+{
+  "docked": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  },
+  "handheld": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  }
+}

--- a/videos/0100187003A36000.json
+++ b/videos/0100187003A36000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Performance analysis",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=_ahNhq2Pj48"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Pokémon™: Let’s Go, Eevee!**.

*   **Title ID:** `0100187003A36000`
*   **Group ID:** `0100187003A36000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.2.
*   Added new graphics settings.
*   Added 1 YouTube link.