### PR TITLE
[Contribution] Super Mario™ 3D World + Bowser’s Fury (010028600EBDA000)

### DIFF
--- a/graphics/010028600EBDA000.json
+++ b/graphics/010028600EBDA000.json
@@ -1,0 +1,29 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked",
+      "notes": "In Bowser's Fury it's locked to 30 FPS"
+    },
+    "resolution": {
+      "maxResolution": "1920x1080",
+      "minResolution": "1280x720",
+      "resolutionType": "Dynamic"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked",
+      "notes": "In Bowser's Fury it's locked to 30 FPS"
+    },
+    "resolution": {
+      "maxResolution": "1280x720",
+      "minResolution": "854x480",
+      "resolutionType": "Dynamic"
+    }
+  }
+}

--- a/profiles/010028600EBDA000/1.2.1.json
+++ b/profiles/010028600EBDA000/1.2.1.json
@@ -1,0 +1,10 @@
+{
+  "docked": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  },
+  "handheld": {
+    "fps_behavior": "Locked",
+    "resolution_type": "Fixed"
+  }
+}

--- a/videos/010028600EBDA000.json
+++ b/videos/010028600EBDA000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Performance analysis",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=8moc-XHuu6I"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Super Mario™ 3D World + Bowser’s Fury**.

*   **Title ID:** `010028600EBDA000`
*   **Group ID:** `010028600EBDA000`

### Summary of Changes
*   Added empty placeholder for performance v1.2.1.
*   Added new graphics settings.
*   Added 1 YouTube link.