### PR TITLE
[Contribution] HYKE:Northern Light(s) (0100EF401D9B2000)

### DIFF
--- a/graphics/0100EF401D9B2000.json
+++ b/graphics/0100EF401D9B2000.json
@@ -1,0 +1,29 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Double (Reversed)",
+      "lockType": "API",
+      "notes": "On top of API Lock there is Custom FPS Lock",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "1920x1080",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Double (Reversed)",
+      "lockType": "API",
+      "notes": "On top of API Lock there is Custom FPS Lock",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "1280x720",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/0100EF401D9B2000/1.0.0.json
+++ b/profiles/0100EF401D9B2000/1.0.0.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/videos/0100EF401D9B2000.json
+++ b/videos/0100EF401D9B2000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=RA-ROKpIP2o"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **HYKE:Northern Light(s)**.

*   **Title ID:** `0100EF401D9B2000`
*   **Group ID:** `0100EF401D9B2000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.0.
*   Added new graphics settings.
*   Updated YouTube links.