### PR TITLE
[Contribution] Pokémon™ Legends: Z-A (0100F43008C44000)

### DIFF
--- a/graphics/0100F43008C44000.json
+++ b/graphics/0100F43008C44000.json
@@ -1,0 +1,29 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Double",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "maxResolution": "1920x1080",
+      "minResolution": "1056x592",
+      "resolutionType": "Dynamic"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Double",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "maxResolution": "1280x720",
+      "minResolution": "704x392",
+      "resolutionType": "Dynamic"
+    }
+  }
+}

--- a/profiles/0100F43008C44000/1.0.1.json
+++ b/profiles/0100F43008C44000/1.0.1.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/videos/0100F43008C44000.json
+++ b/videos/0100F43008C44000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=N88zCu6NeH4"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Pokémon™ Legends: Z-A**.

*   **Title ID:** `0100F43008C44000`
*   **Group ID:** `0100F43008C44000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.1.
*   Added new graphics settings.
*   Updated YouTube links.