### PR TITLE
[Contribution] Minecraft: Nintendo Switch Edition (01006BD001E06000)

### DIFF
--- a/graphics/01006BD001E06000.json
+++ b/graphics/01006BD001E06000.json
@@ -1,0 +1,25 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "1920x1080",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "1280x720",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/01006BD001E06000/1.0.17.json
+++ b/profiles/01006BD001E06000/1.0.17.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **Minecraft: Nintendo Switch Edition**.

*   **Title ID:** `01006BD001E06000`
*   **Group ID:** `01006BD001E06000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.17.
*   Added new graphics settings.