### PR TITLE
[Contribution] Double Dragon Revive (01006AE02236C000)

### DIFF
--- a/graphics/01006AE02236C000.json
+++ b/graphics/01006AE02236C000.json
@@ -1,0 +1,29 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Double (Reversed)",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "maxResolution": "1600x900",
+      "minResolution": "400x225",
+      "resolutionType": "Dynamic"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Double (Reversed)",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "maxResolution": "1280x720",
+      "minResolution": "320x180",
+      "resolutionType": "Dynamic"
+    }
+  }
+}

--- a/profiles/01006AE02236C000/N1.10.json
+++ b/profiles/01006AE02236C000/N1.10.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/videos/01006AE02236C000.json
+++ b/videos/01006AE02236C000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=oQZVG37YEsk"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Double Dragon Revive**.

*   **Title ID:** `01006AE02236C000`
*   **Group ID:** `01006AE02236C000`

### Summary of Changes
*   Added empty placeholder for performance vN1.10.
*   Added new graphics settings.
*   Updated YouTube links.