### PR TITLE
[Contribution] ドラゴンクエストヒーローズI・II for Nintendo Switch (0100CD3000BDC000)

### DIFF
--- a/graphics/0100CD3000BDC000.json
+++ b/graphics/0100CD3000BDC000.json
@@ -1,0 +1,29 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Double",
+      "lockType": "Custom",
+      "notes": "In menus FPS is Unlocked",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "1920x1080",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Double",
+      "lockType": "Custom",
+      "notes": "In menus FPS is Unlocked",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "1280x720",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/0100CD3000BDC000/1.0.3.json
+++ b/profiles/0100CD3000BDC000/1.0.3.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **ドラゴンクエストヒーローズI・II for Nintendo Switch**.

*   **Title ID:** `0100CD3000BDC000`
*   **Group ID:** `0100CD3000BDC000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.3.
*   Added new graphics settings.