### PR TITLE
[Contribution] LEGO® Party! (0100A760232D2000)

### DIFF
--- a/graphics/0100A760232D2000.json
+++ b/graphics/0100A760232D2000.json
@@ -1,0 +1,27 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "1920x1080",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "1280x720",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/0100A760232D2000/1.2.0.json
+++ b/profiles/0100A760232D2000/1.2.0.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/videos/0100A760232D2000.json
+++ b/videos/0100A760232D2000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=6B0kCmv1EwA"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **LEGO® Party!**.

*   **Title ID:** `0100A760232D2000`
*   **Group ID:** `0100A760232D2000`

### Summary of Changes
*   Added empty placeholder for performance v1.2.0.
*   Added new graphics settings.
*   Updated YouTube links.