### PR TITLE
[Contribution] Cities: Skylines - Nintendo Switch™ Edition (0100D8800B87C000)

### DIFF
--- a/graphics/0100D8800B87C000.json
+++ b/graphics/0100D8800B87C000.json
@@ -1,0 +1,25 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "1440x810",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "960x540",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/0100D8800B87C000/1.0.3.37670.json
+++ b/profiles/0100D8800B87C000/1.0.3.37670.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/videos/0100D8800B87C000.json
+++ b/videos/0100D8800B87C000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Docked gameplay with FPS Graph",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=rRcBoxJVQ9Q"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Cities: Skylines - Nintendo Switch™ Edition**.

*   **Title ID:** `0100D8800B87C000`
*   **Group ID:** `0100D8800B87C000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.3.37670.
*   Added new graphics settings.
*   Updated YouTube links.