### PR TITLE
[Contribution] Saints Row IV®: Re-Elected™ (01008D100D43E000)

### DIFF
--- a/graphics/01008D100D43E000.json
+++ b/graphics/01008D100D43E000.json
@@ -1,0 +1,29 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "maxResolution": "1920x1080",
+      "minResolution": "1280x720",
+      "notes": "Disabled dynamic resolution results in Fixed 1920x1080. Dynamic resolution targets 30 FPS.",
+      "resolutionType": "Dynamic"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "maxResolution": "1280x720",
+      "minResolution": "854x480",
+      "notes": "Disabled dynamic resolution results in Fixed 1280x720. Dynamic resolution targets 30 FPS.",
+      "resolutionType": "Dynamic"
+    }
+  }
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **Saints Row IV®: Re-Elected™**.

*   **Title ID:** `01008D100D43E000`
*   **Group ID:** `01008D100D43E000`

### Summary of Changes
*   Updated graphics settings.