### PR TITLE
[Contribution] Descenders (0100C2F013084000)

### DIFF
--- a/graphics/0100C2F013084000.json
+++ b/graphics/0100C2F013084000.json
@@ -1,0 +1,26 @@
+{
+  "contributor": [
+    "biase-d"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Unknown",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Double",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "1280x720",
+      "notes": "Test...",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/0100C2F013084000/1.1.1.json
+++ b/profiles/0100C2F013084000/1.1.1.json
@@ -1,5 +1,5 @@
 {
   "contributor": [
-    "masagrator"
+    "biase-d"
   ]
 }


### PR DESCRIPTION
Contribution submitted by @biase-d for **Descenders**.

*   **Title ID:** `0100D4600D0E4000`
*   **Group ID:** `0100C2F013084000`

### Summary of Changes
*   Added empty placeholder for performance v1.1.1.
*   Removed performance profile for v1.0.0.
*   Added new graphics settings.