### PR TITLE
[Contribution] Nickelodeon Kart Racers (0100BD900A3FC000)

### DIFF
--- a/graphics/0100BD900A3FC000.json
+++ b/graphics/0100BD900A3FC000.json
@@ -1,0 +1,25 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Double",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "1920x1080",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Double",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "1280x720",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/0100BD900A3FC000/1.0.4.json
+++ b/profiles/0100BD900A3FC000/1.0.4.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **Nickelodeon Kart Racers**.

*   **Title ID:** `0100BD900A3FC000`
*   **Group ID:** `0100BD900A3FC000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.4.
*   Added new graphics settings.