### PR TITLE
[Contribution] Nickelodeon Kart Racers 3: Slime Speedway (01003BA01575E000)

### DIFF
--- a/graphics/01003BA01575E000.json
+++ b/graphics/01003BA01575E000.json
@@ -1,0 +1,29 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "maxResolution": "1360x768",
+      "minResolution": "1138x640",
+      "resolutionType": "Dynamic"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "maxResolution": "1088x612",
+      "minResolution": "912x512",
+      "resolutionType": "Dynamic"
+    }
+  }
+}

--- a/profiles/01003BA01575E000/0.3.2.15969.json
+++ b/profiles/01003BA01575E000/0.3.2.15969.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/videos/01003BA01575E000.json
+++ b/videos/01003BA01575E000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=W_CzkjV6yC4"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Nickelodeon Kart Racers 3: Slime Speedway**.

*   **Title ID:** `01003BA01575E000`
*   **Group ID:** `01003BA01575E000`

### Summary of Changes
*   Added empty placeholder for performance v0.3.2.15969.
*   Added new graphics settings.
*   Updated YouTube links.