### PR TITLE
[Contribution] Nuclear Throne (0100CFE00CE6E000)

### DIFF
--- a/graphics/0100CFE00CE6E000.json
+++ b/graphics/0100CFE00CE6E000.json
@@ -1,0 +1,29 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Custom",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "320x240",
+      "notes": "Nearest neighbor scaling matching TV Resolution set in System Settings.",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Custom",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "320x240",
+      "notes": "Nearest neighbor scaling.",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/0100CFE00CE6E000/1.0.11.json
+++ b/profiles/0100CFE00CE6E000/1.0.11.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **Nuclear Throne**.

*   **Title ID:** `0100CFE00CE6E000`
*   **Group ID:** `0100CFE00CE6E000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.11.
*   Added new graphics settings.