### PR TITLE
[Contribution] PROGRESS ORDERS (01000F801EC5A000)

### DIFF
--- a/graphics/01000F801EC5A000.json
+++ b/graphics/01000F801EC5A000.json
@@ -1,0 +1,27 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Double (Reversed)",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "1068x600",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Double (Reversed)",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "854x480",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/01000F801EC5A000/1.0.3.json
+++ b/profiles/01000F801EC5A000/1.0.3.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/videos/01000F801EC5A000.json
+++ b/videos/01000F801EC5A000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=--PgG0kMlaQ"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **PROGRESS ORDERS**.

*   **Title ID:** `01000F801EC5A000`
*   **Group ID:** `01000F801EC5A000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.3.
*   Added new graphics settings.
*   Updated YouTube links.