### PR TITLE
[Contribution] Metroid Prime™ 4: Beyond (010019A01E2F2000)

### DIFF
--- a/graphics/010019A01E2F2000.json
+++ b/graphics/010019A01E2F2000.json
@@ -1,0 +1,29 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "maxResolution": "1440x810",
+      "minResolution": "1245x700",
+      "notes": "Resolution above is for stuff before the MC's visor. Everything else is rendered at Fixed 1600x900. Resolution seems to be adjusted based on complexity of rendered scene without any look into how long it takes to render frame.",
+      "resolutionType": "Dynamic"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "maxResolution": "864x468",
+      "minResolution": "747x420",
+      "notes": "Resolution above is for stuff before the MC's visor. Everything else is rendered at Fixed 1024x576. Resolution seems to be adjusted based on complexity of rendered scene without any look into how long it takes to render frame.",
+      "resolutionType": "Dynamic"
+    }
+  }
+}

--- a/profiles/010019A01E2F2000/1.1.0.json
+++ b/profiles/010019A01E2F2000/1.1.0.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/videos/010019A01E2F2000.json
+++ b/videos/010019A01E2F2000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=HH5bRZGkihQ"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Metroid Prime™ 4: Beyond**.

*   **Title ID:** `010019A01E2F2000`
*   **Group ID:** `010019A01E2F2000`

### Summary of Changes
*   Added empty placeholder for performance v1.1.0.
*   Added new graphics settings.
*   Updated YouTube links.