### PR TITLE
[Contribution] Mercenaries Blaze: Dawn of the Twin Dragons (0100A790133FC000)

### DIFF
--- a/graphics/0100A790133FC000.json
+++ b/graphics/0100A790133FC000.json
@@ -1,0 +1,25 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "1920x1080",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "1280x720",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/0100A790133FC000/1.0.1.json
+++ b/profiles/0100A790133FC000/1.0.1.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **Mercenaries Blaze: Dawn of the Twin Dragons**.

*   **Title ID:** `0100A790133FC000`
*   **Group ID:** `0100A790133FC000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.1.
*   Added new graphics settings.