### PR TITLE
[Contribution] Asterix & Obelix XXL: Romastered (0100F46011B50000)

### DIFF
--- a/graphics/0100F46011B50000.json
+++ b/graphics/0100F46011B50000.json
@@ -1,0 +1,25 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "1280x720",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "960x540",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/0100F46011B50000/1.0.34.0.json
+++ b/profiles/0100F46011B50000/1.0.34.0.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **Asterix & Obelix XXL: Romastered**.

*   **Title ID:** `0100F46011B50000`
*   **Group ID:** `0100F46011B50000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.34.0.
*   Added new graphics settings.