### PR TITLE
[Contribution] Diesel Legacy: The Brazen Age (010076001F5DA000)

### DIFF
--- a/graphics/010076001F5DA000.json
+++ b/graphics/010076001F5DA000.json
@@ -1,0 +1,27 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Double",
+      "lockType": "Custom",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "1280x720",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Double",
+      "lockType": "Custom",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "1280x720",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/010076001F5DA000/1.0.4.json
+++ b/profiles/010076001F5DA000/1.0.4.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/videos/010076001F5DA000.json
+++ b/videos/010076001F5DA000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=OcP0fncxNRc"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Diesel Legacy: The Brazen Age**.

*   **Title ID:** `010076001F5DA000`
*   **Group ID:** `010076001F5DA000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.4.
*   Added new graphics settings.
*   Updated YouTube links.