### PR TITLE
[Contribution] Warhammer 40,000: Dakka Squadron (01007B301CFBE000)

### DIFF
--- a/graphics/01007B301CFBE000.json
+++ b/graphics/01007B301CFBE000.json
@@ -1,0 +1,27 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "854x480",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "854x480",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/01007B301CFBE000/1.0.2.json
+++ b/profiles/01007B301CFBE000/1.0.2.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/videos/01007B301CFBE000.json
+++ b/videos/01007B301CFBE000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=FSgzjQk_Jlc"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Warhammer 40,000: Dakka Squadron**.

*   **Title ID:** `01007B301CFBE000`
*   **Group ID:** `01007B301CFBE000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.2.
*   Added new graphics settings.
*   Updated YouTube links.