### PR TITLE
[Contribution] Garfield Kart 2 - All You Can Drift (0100DC9020B30000)

### DIFF
--- a/graphics/0100DC9020B30000.json
+++ b/graphics/0100DC9020B30000.json
@@ -1,0 +1,31 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "notes": "Main menu runs Unlocked.",
+      "targetFps": 30
+    },
+    "resolution": {
+      "maxResolution": "1600x900",
+      "minResolution": "800x450",
+      "resolutionType": "Dynamic"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "notes": "Main menu runs Unlocked.",
+      "targetFps": 30
+    },
+    "resolution": {
+      "maxResolution": "1067x600",
+      "minResolution": "534x300",
+      "resolutionType": "Dynamic"
+    }
+  }
+}

--- a/profiles/0100DC9020B30000/1.0.5.json
+++ b/profiles/0100DC9020B30000/1.0.5.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **Garfield Kart 2 - All You Can Drift**.

*   **Title ID:** `0100DC9020B30000`
*   **Group ID:** `0100DC9020B30000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.5.
*   Added new graphics settings.