### PR TITLE
[Contribution] MONOPOLY® for Nintendo Switch™ (01007430037F6000)

### DIFF
--- a/graphics/01007430037F6000.json
+++ b/graphics/01007430037F6000.json
@@ -1,0 +1,29 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "notes": "Classic boards run at 60 FPS.",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "1920x1080",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "API",
+      "notes": "Classic boards run at 60 FPS.",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "1280x720",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/01007430037F6000/1.0.5.json
+++ b/profiles/01007430037F6000/1.0.5.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **MONOPOLY® for Nintendo Switch™**.

*   **Title ID:** `01007430037F6000`
*   **Group ID:** `01007430037F6000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.5.
*   Added new graphics settings.