### PR TITLE
[Contribution] Tropico 6 - Nintendo Switch™ Edition (0100FBE0113CC000)

### DIFF
--- a/graphics/0100FBE0113CC000.json
+++ b/graphics/0100FBE0113CC000.json
@@ -1,0 +1,25 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "1280x720",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "848x476",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/0100FBE0113CC000/1.0.6.json
+++ b/profiles/0100FBE0113CC000/1.0.6.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **Tropico 6 - Nintendo Switch™ Edition**.

*   **Title ID:** `0100FBE0113CC000`
*   **Group ID:** `0100FBE0113CC000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.6.
*   Added new graphics settings.