### PR TITLE
[Contribution] STAR WARS™ Jedi Knight II: Jedi Outcast™ (0100BB500EACA000)

### DIFF
--- a/graphics/0100BB500EACA000.json
+++ b/graphics/0100BB500EACA000.json
@@ -1,0 +1,25 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "1920x1080",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "1920x1080",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/0100BB500EACA000/1.0.5.json
+++ b/profiles/0100BB500EACA000/1.0.5.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/videos/0100BB500EACA000.json
+++ b/videos/0100BB500EACA000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Platform comparison with FPS Graph",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=CmFZP8fmy_M"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **STAR WARS™ Jedi Knight II: Jedi Outcast™**.

*   **Title ID:** `0100BB500EACA000`
*   **Group ID:** `0100BB500EACA000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.5.
*   Added new graphics settings.
*   Updated YouTube links.