### PR TITLE
[Contribution] Prinny® 2: Dawn of Operation Panties, Dood! (01008FA01187A000)

### DIFF
--- a/graphics/01008FA01187A000.json
+++ b/graphics/01008FA01187A000.json
@@ -1,0 +1,27 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "480x272",
+      "notes": "Game is integer scaled to 1280x720.",
+      "resolutionType": "Fixed"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Triple",
+      "lockType": "Unlocked"
+    },
+    "resolution": {
+      "fixedResolution": "480x272",
+      "notes": "Game is integer scaled to 960x540.",
+      "resolutionType": "Fixed"
+    }
+  }
+}

--- a/profiles/01008FA01187A000/1.0.3.json
+++ b/profiles/01008FA01187A000/1.0.3.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}


### PR DESCRIPTION
Contribution submitted by @masagrator for **Prinny® 2: Dawn of Operation Panties, Dood!**.

*   **Title ID:** `01008FA01187A000`
*   **Group ID:** `01008FA01187A000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.3.
*   Added new graphics settings.