### PR TITLE
[Contribution] Beyond Hanwell: Nintendo Switch™ Edition (01004310229EE000)

### DIFF
--- a/graphics/01004310229EE000.json
+++ b/graphics/01004310229EE000.json
@@ -1,0 +1,31 @@
+{
+  "contributor": [
+    "masagrator"
+  ],
+  "docked": {
+    "framerate": {
+      "apiBuffering": "Double (Reversed)",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "1280x720",
+      "maxResolution": "1920x1080",
+      "minResolution": "960x540",
+      "resolutionType": "Dynamic"
+    }
+  },
+  "handheld": {
+    "framerate": {
+      "apiBuffering": "Double (Reversed)",
+      "lockType": "API",
+      "targetFps": 30
+    },
+    "resolution": {
+      "fixedResolution": "854x480",
+      "maxResolution": "1280x720",
+      "minResolution": "640x360",
+      "resolutionType": "Dynamic"
+    }
+  }
+}

--- a/profiles/01004310229EE000/1.0.json
+++ b/profiles/01004310229EE000/1.0.json
@@ -1,0 +1,5 @@
+{
+  "contributor": [
+    "masagrator"
+  ]
+}

--- a/videos/01004310229EE000.json
+++ b/videos/01004310229EE000.json
@@ -1,0 +1,7 @@
+[
+  {
+    "notes": "Docked gameplay with FPS Counter",
+    "submittedBy": "masagrator",
+    "url": "https://www.youtube.com/watch?v=JqY-LrTFs_I"
+  }
+]


### PR DESCRIPTION
Contribution submitted by @masagrator for **Beyond Hanwell: Nintendo Switch™ Edition**.

*   **Title ID:** `01004310229EE000`
*   **Group ID:** `01004310229EE000`

### Summary of Changes
*   Added empty placeholder for performance v1.0.
*   Added new graphics settings.
*   Updated YouTube links.